### PR TITLE
Make size of BUFFER_ERROR equal to CURL_ERROR_SIZE

### DIFF
--- a/src/web_client.c
+++ b/src/web_client.c
@@ -26,7 +26,7 @@
 
 #define FILE_COOKIE "/tmp/dictcc_cookie.txt"
 
-#define BUFFER_ERROR 256
+#define BUFFER_ERROR CURL_ERROR_SIZE
 
 
 // ________________________________________________________________


### PR DESCRIPTION
Making the error buffer's size equal to CURL_ERROR_SIZE is better than hard coding a figure since that constant might change anytime within libcurl.